### PR TITLE
Initstatus

### DIFF
--- a/pkg/openapi/cluster/usecase/install_usecase.go
+++ b/pkg/openapi/cluster/usecase/install_usecase.go
@@ -97,6 +97,7 @@ type InstallUseCaseImpl struct {
 	downloadListener *downloadutil.DownloadWithProgress
 	downloadError    error
 	checked          bool
+	downloaded       bool //only when precheck check file exists set as true
 }
 
 // NewInstallUseCase new install case
@@ -121,6 +122,7 @@ func (ic *InstallUseCaseImpl) InstallPreCheck() (model.StatusRes, error) {
 			downStatus.Message = err.Error()
 		}
 	} else {
+		ic.downloaded = true
 		downStatus.Status = InstallStatusFinished
 		downStatus.Progress = 100
 	}
@@ -322,19 +324,36 @@ func (ic *InstallUseCaseImpl) parseInstallStatus(source *v1alpha1.RainbondCluste
 		return
 	}
 	statuses := make([]model.InstallStatus, 0)
+
 	statuses = append(statuses, ic.stepSetting())
-	statuses = append(statuses, ic.stepDownload())
-	statuses = append(statuses, ic.stepPrepareInfrastructure(source))
-	statuses = append(statuses, ic.stepUnpack(source))
-	statuses = append(statuses, ic.stepHandleImage(source))
-	statuses = append(statuses, ic.stepCreateComponent(source))
+
+	downloadStatus := ic.stepDownload()
+	statuses = append(statuses, downloadStatus)
+
+	infrastructureStatus := ic.stepPrepareInfrastructure(source, downloadStatus.Status == InstallStatusWaiting)
+	statuses = append(statuses, infrastructureStatus)
+
+	unpackStatus := ic.stepUnpack(source, infrastructureStatus.Status == InstallStatusWaiting)
+	statuses = append(statuses, unpackStatus)
+
+	handleImageStatus := ic.stepHandleImage(source, unpackStatus.Status == InstallStatusWaiting)
+	statuses = append(statuses, handleImageStatus)
+
+	createComponentStatus := ic.stepCreateComponent(source, handleImageStatus.Status == InstallStatusWaiting)
+	statuses = append(statuses, createComponentStatus)
+
 	finalStatus := InstallStatusFinished
-	for _, status := range statuses {
-		if status.Status != InstallStatusFinished {
-			finalStatus = InstallStatusProcessing
-			break
+	if downloadStatus.Status == InstallStatusWaiting {
+		finalStatus = InstallStatusWaiting // have not installed
+	} else {
+		for _, status := range statuses {
+			if status.Status != InstallStatusFinished {
+				finalStatus = InstallStatusProcessing
+				break
+			}
 		}
 	}
+
 	statusres = model.StatusRes{
 		FinalStatus: finalStatus,
 		StatusList:  statuses,
@@ -355,6 +374,23 @@ func (ic *InstallUseCaseImpl) stepSetting() model.InstallStatus {
 // step 2 download rainbond
 func (ic *InstallUseCaseImpl) stepDownload() model.InstallStatus {
 	defer commonutil.TimeConsume(time.Now())
+	if ic.downloadListener != nil {
+		// downloading
+		return model.InstallStatus{
+			StepName: StepDownload,
+			Status:   InstallStatusProcessing,
+			Progress: ic.downloadListener.Percent,
+		}
+	}
+
+	if !ic.downloaded {
+		// have not installed
+		return model.InstallStatus{
+			StepName: StepDownload,
+			Status:   InstallStatusWaiting,
+		}
+	}
+
 	installStatus := model.InstallStatus{
 		StepName: StepDownload,
 		Status:   InstallStatusFinished,
@@ -364,8 +400,14 @@ func (ic *InstallUseCaseImpl) stepDownload() model.InstallStatus {
 }
 
 // step 3 prepare storage and image hub
-func (ic *InstallUseCaseImpl) stepPrepareInfrastructure(source *v1alpha1.RainbondClusterStatus) model.InstallStatus {
+func (ic *InstallUseCaseImpl) stepPrepareInfrastructure(source *v1alpha1.RainbondClusterStatus, waiting bool) model.InstallStatus {
 	defer commonutil.TimeConsume(time.Now())
+	if waiting {
+		return model.InstallStatus{
+			StepName: StepPrepareInfrastructure,
+			Status:   InstallStatusWaiting,
+		}
+	}
 	var status model.InstallStatus
 	switch source.Phase {
 	case v1alpha1.RainbondClusterWaiting:
@@ -403,8 +445,14 @@ func (ic *InstallUseCaseImpl) stepPrepareInfrastructure(source *v1alpha1.Rainbon
 }
 
 // step 4 unpack rainbond
-func (ic *InstallUseCaseImpl) stepUnpack(source *v1alpha1.RainbondClusterStatus) model.InstallStatus {
+func (ic *InstallUseCaseImpl) stepUnpack(source *v1alpha1.RainbondClusterStatus, waiting bool) model.InstallStatus {
 	defer commonutil.TimeConsume(time.Now())
+	if waiting {
+		return model.InstallStatus{
+			StepName: StepUnpack,
+			Status:   InstallStatusWaiting,
+		}
+	}
 	status := model.InstallStatus{
 		StepName: StepUnpack,
 	}
@@ -441,8 +489,14 @@ func (ic *InstallUseCaseImpl) getRainbondPackageStatus() *v1alpha1.RainbondPacka
 }
 
 // step 5 handle image, load and push image to image hub
-func (ic *InstallUseCaseImpl) stepHandleImage(source *v1alpha1.RainbondClusterStatus) model.InstallStatus {
+func (ic *InstallUseCaseImpl) stepHandleImage(source *v1alpha1.RainbondClusterStatus, waiting bool) model.InstallStatus {
 	defer commonutil.TimeConsume(time.Now())
+	if waiting {
+		return model.InstallStatus{
+			StepName: StepHandleImage,
+			Status:   InstallStatusWaiting,
+		}
+	}
 	status := model.InstallStatus{
 		StepName: StepHandleImage,
 	}
@@ -470,8 +524,14 @@ func (ic *InstallUseCaseImpl) stepHandleImage(source *v1alpha1.RainbondClusterSt
 }
 
 // step 6 create component
-func (ic *InstallUseCaseImpl) stepCreateComponent(source *v1alpha1.RainbondClusterStatus) model.InstallStatus {
+func (ic *InstallUseCaseImpl) stepCreateComponent(source *v1alpha1.RainbondClusterStatus, waiting bool) model.InstallStatus {
 	defer commonutil.TimeConsume(time.Now())
+	if waiting {
+		return model.InstallStatus{
+			StepName: StepInstallComponent,
+			Status:   InstallStatusWaiting,
+		}
+	}
 	var status model.InstallStatus
 	switch source.Phase {
 	case v1alpha1.RainbondClusterWaiting, v1alpha1.RainbondClusterPreparing, v1alpha1.RainbondClusterPackageProcessing:

--- a/pkg/openapi/cluster/usecase/install_usecase.go
+++ b/pkg/openapi/cluster/usecase/install_usecase.go
@@ -330,16 +330,16 @@ func (ic *InstallUseCaseImpl) parseInstallStatus(source *v1alpha1.RainbondCluste
 	downloadStatus := ic.stepDownload()
 	statuses = append(statuses, downloadStatus)
 
-	infrastructureStatus := ic.stepPrepareInfrastructure(source, downloadStatus.Status == InstallStatusWaiting)
+	infrastructureStatus := ic.stepPrepareInfrastructure(source, downloadStatus.Status != InstallStatusFinished)
 	statuses = append(statuses, infrastructureStatus)
 
-	unpackStatus := ic.stepUnpack(source, infrastructureStatus.Status == InstallStatusWaiting)
+	unpackStatus := ic.stepUnpack(source, infrastructureStatus.Status != InstallStatusFinished)
 	statuses = append(statuses, unpackStatus)
 
-	handleImageStatus := ic.stepHandleImage(source, unpackStatus.Status == InstallStatusWaiting)
+	handleImageStatus := ic.stepHandleImage(source, unpackStatus.Status != InstallStatusFinished)
 	statuses = append(statuses, handleImageStatus)
 
-	createComponentStatus := ic.stepCreateComponent(source, handleImageStatus.Status == InstallStatusWaiting)
+	createComponentStatus := ic.stepCreateComponent(source, handleImageStatus.Status != InstallStatusFinished)
 	statuses = append(statuses, createComponentStatus)
 
 	finalStatus := InstallStatusFinished


### PR DESCRIPTION
1、修改安装状态
通过/cluster/install/status接口获取集群安装状态
status_waiting为未安装状态，
status_processing为安装中状态
status_finished 为安装成功页面

当为安装中状态时，重新载入页面仍应该进入安装页面
安装成功应该进入组件管理页面

2、优化安装状态获取
上个步骤未完成，下个步骤应为waiting状态